### PR TITLE
Remove unnecessary dependencies and upgrade other dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,6 @@ repositories {
 
 dependencies {
     compile 'org.apache.commons:commons-configuration2:2.0'
-    compile 'commons-beanutils:commons-beanutils:1.9.2'
     compile 'com.fasterxml.jackson.core:jackson-core:2.6.0'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.6.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,15 @@ repositories {
 
 dependencies {
     compile 'org.apache.commons:commons-configuration2:2.0'
-    compile 'com.fasterxml.jackson.core:jackson-core:2.6.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.6.0'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.5'
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.5' // upgrade 2.7.0 dependency of jackson-databind
 
     provided 'com.google.code.findbugs:findbugs:3.0.1'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.6.0'
-    testCompile 'com.google.guava:guava:17.0'
+    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5'
+    testCompile 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
+    testCompile 'com.google.guava:guava:18.0'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
     testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5'
     testCompile 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
     testCompile 'com.google.guava:guava:18.0'
+    testCompile 'commons-beanutils:commons-beanutils:1.9.2'
+    testCompile 'commons-collections:commons-collections:3.2.2' // upgrade 3.2.1 dependency of commons-collections (http://www.kb.cert.org/vuls/id/576313)
 }
 
 


### PR DESCRIPTION
- got rid of commons-beanutils-1.9.2.jar
- got rid of commons-collections-3.2.1.jar (transitive dependency of commons-beanutils-1.9.2.jar with vulnerability http://www.kb.cert.org/vuls/id/576313)
- upgraded jackson-core-2.6.0.jar to jackson-core-2.7.5.jar
- upgraded jackson-databind-2.6.0.jar to jackson-databind-2.7.5.jar
- upgraded jackson-annotations-2.6.0.jar to jackson-annotations-2.7.5.jar
- upgraded jackson-dataformat-yaml-2.6.0.jar to jackson-dataformat-yaml-2.7.5.jar
- upgraded snakeyaml-1.15.jar to snakeyaml-1.17.jar
