### PR TITLE
Properly upgrade dependencies and resolve conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,19 +24,34 @@ repositories {
 
 dependencies {
     compile 'org.apache.commons:commons-configuration2:2.0'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.5'
+    compile ('com.fasterxml.jackson.core:jackson-databind:2.7.5') {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+    }
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.5' // upgrade 2.7.0 dependency of jackson-databind
 
     provided 'com.google.code.findbugs:findbugs:3.0.1'
 
     testCompile 'junit:junit:4.12'
-    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5'
+
+    testCompile ('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5') {
+        exclude group: 'org.yaml', module: 'snakeyaml'
+    }
     testCompile 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
+
     testCompile 'com.google.guava:guava:18.0'
-    testCompile 'commons-beanutils:commons-beanutils:1.9.2'
+
+    testCompile ('commons-beanutils:commons-beanutils:1.9.2') {
+        exclude group: 'commons-logging', module: 'commons-logging' // conflicts with commons-configuration2
+        exclude group: 'commons-collections', module: 'commons-collections'
+    }
     testCompile 'commons-collections:commons-collections:3.2.2' // upgrade 3.2.1 dependency of commons-collections (http://www.kb.cert.org/vuls/id/576313)
 }
 
+configurations.all {
+    resolutionStrategy {
+        failOnVersionConflict()
+    }
+}
 
 sourceSets.main.compileClasspath += configurations.provided
 idea.module.scopes.PROVIDED.plus += [configurations.provided]

--- a/build.gradle
+++ b/build.gradle
@@ -24,32 +24,24 @@ repositories {
 
 dependencies {
     compile 'org.apache.commons:commons-configuration2:2.0'
-    compile ('com.fasterxml.jackson.core:jackson-databind:2.7.5') {
-        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
-    }
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.7.5' // upgrade 2.7.0 dependency of jackson-databind
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.5'
 
     provided 'com.google.code.findbugs:findbugs:3.0.1'
 
     testCompile 'junit:junit:4.12'
-
-    testCompile ('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5') {
-        exclude group: 'org.yaml', module: 'snakeyaml'
-    }
-    testCompile 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
-
+    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.7.5'
     testCompile 'com.google.guava:guava:18.0'
-
-    testCompile ('commons-beanutils:commons-beanutils:1.9.2') {
-        exclude group: 'commons-logging', module: 'commons-logging' // conflicts with commons-configuration2
-        exclude group: 'commons-collections', module: 'commons-collections'
-    }
-    testCompile 'commons-collections:commons-collections:3.2.2' // upgrade 3.2.1 dependency of commons-collections (http://www.kb.cert.org/vuls/id/576313)
+    testCompile 'commons-beanutils:commons-beanutils:1.9.2'
 }
 
 configurations.all {
     resolutionStrategy {
         failOnVersionConflict()
+
+        force 'com.fasterxml.jackson.core:jackson-annotations:2.7.5' // upgrade 2.7.0 dependency of jackson-databind
+        force 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
+        force 'commons-collections:commons-collections:3.2.2' // upgrade 3.2.1 dependency of commons-collections (http://www.kb.cert.org/vuls/id/576313)
+        force 'commons-logging:commons-logging:1.2' // resolve conflict between commons-configuration2 and commons-beanutils
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ configurations.all {
     resolutionStrategy {
         failOnVersionConflict()
 
+        force 'org.apache.commons:commons-lang3:3.4' // updgrade 3.3.2 dependency of commons-configuration2
         force 'com.fasterxml.jackson.core:jackson-annotations:2.7.5' // upgrade 2.7.0 dependency of jackson-databind
         force 'org.yaml:snakeyaml:1.17' // upgrade 1.15 dependency of jackson-dataformat-yaml
         force 'commons-collections:commons-collections:3.2.2' // upgrade 3.2.1 dependency of commons-collections (http://www.kb.cert.org/vuls/id/576313)


### PR DESCRIPTION
Not a major issue, but the way I upgraded some of the dependencies in my previous pull request relies on Maven/Gradle to automatically solve conflicts by picking the latest versions of the libraries. I found out that this is not the proper way to do it and it makes Gradle's  failOnVersionConflict() check fail for projects that transitively depend on commons-configuration2-jackson. This pull requests fixes this issue. I also added the failOnVersionConflict() check to this project to make sure that such issues won't be introduced again.
